### PR TITLE
Posible corrección del WSDL de Recepció de Reports

### DIFF
--- a/missatgeria/4.0/wsdl/RecepcioReports.wsdl
+++ b/missatgeria/4.0/wsdl/RecepcioReports.wsdl
@@ -26,7 +26,7 @@
 		</s:schema>
 		<s:schema
 			xmlns="http://www.aocat.net/NT/v4.0" 
-			targetNamespace="http://www.aocat.net/NT/v3.2"
+			targetNamespace="http://www.aocat.net/NT/v4.0"
 			elementFormDefault="qualified" 
 			attributeFormDefault="unqualified">
 
@@ -41,7 +41,7 @@
 	<wsdl:message name="clientRequestwithReturnSoapOut">
 		<wsdl:part name="parameters" element="s0:clientRequestwithReturnResponse" />
 	</wsdl:message>
-	<wsdl:portType name="ReportReceiverv3Soap">
+	<wsdl:portType name="ReportReceiverSoap">
 		<wsdl:operation name="clientRequestwithReturn">
 			<wsdl:input message="s0:clientRequestwithReturnSoapIn" />
 			<wsdl:output message="s0:clientRequestwithReturnSoapOut" />


### PR DESCRIPTION
Se cambió el namespace objetivo de v3.2 a v4.0. Además, se renombró el portType de "ReportReceiverv3Soap" a "ReportReceiverSoap".

Cuando se intentaba crear el interface para el servicio web encontrábamos errores:

```
d:\eNotumAOC\missatgeria\4.0\wsdl>wsdl RecepcioReports.wsdl /serverInterface
Microsoft (R) Web Services Description Language Utility
[Microsoft (R) .NET Framework, Version 4.8.3928.0]
Copyright (C) Microsoft Corporation. All rights reserved.
Error: Element message named ReportReceiverSoap from namespace http://www.openuri.org/ is missing.

If you would like more help, please type "wsdl /?".
```

Tras analizar el contenido del fichero WSDL veíamos que todavía se apuntaba al 'namespace' de la versión 3.2, además de que el 'binding' tenía un nombre inexistente en el propio WSDL.

Tras los cambios la generación de la interface no daba problemas:

```
d:\eNotumAOC\missatgeria\4.0\wsdl>wsdl RecepcioReports.wsdl /serverInterface
Microsoft (R) Web Services Description Language Utility
[Microsoft (R) .NET Framework, Version 4.8.3928.0]
Copyright (C) Microsoft Corporation. All rights reserved.
Writing file 'd:\eNotumAOC\missatgeria\4.0\wsdl\ReportReceivervInterfaces.cs'.
```